### PR TITLE
fix: mejorar área de hover de tooltips para evitar interferencia con …

### DIFF
--- a/src/components/molecules/FieldWrapper/FieldWrapper.tsx
+++ b/src/components/molecules/FieldWrapper/FieldWrapper.tsx
@@ -16,7 +16,7 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
     <label htmlFor={name} className="text-base font-semibold text-gray-700 dark:text-white mb-2 drop-shadow flex items-center gap-2">
       {label} {required && <span className="text-red-500">*</span>}
       {tooltip && (
-        <div className="group relative">
+        <div className="group relative inline-block">
           <Info className="h-4 w-4 text-blue-500 dark:text-blue-400 cursor-help" aria-hidden="true" />
           <button
             type="button"
@@ -37,9 +37,9 @@ const FieldWrapper: React.FC<FieldWrapperProps> = ({
           <div
             id={`${name}-tooltip`}
             role="tooltip"
-            // Estilos del tooltip tomados de features/auth/components/FieldWrapper.tsx y ajustados
-            className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-4 py-2 bg-gray-800/95 dark:bg-gray-900/95 text-white text-sm font-semibold rounded-xl opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200 w-56 shadow-2xl border border-blue-400 z-20"
-            aria-hidden="true" // Se maneja con JS y hover/focus
+         
+            className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-4 py-2 bg-gray-800/95 dark:bg-gray-900/95 text-white text-sm font-semibold rounded-xl opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200 w-56 shadow-2xl border border-blue-400 z-50 pointer-events-none"
+            aria-hidden="true" 
           >
             {tooltip}
           </div>

--- a/src/components/ui/PasswordToggle.tsx
+++ b/src/components/ui/PasswordToggle.tsx
@@ -56,7 +56,7 @@ export const PasswordToggle = ({
           onClick={togglePasswordVisibility}
           disabled={disabled}
           className={cn(
-            'absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-colors',
+            'absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-colors p-1 rounded z-10',
             disabled && 'cursor-not-allowed opacity-50',
             buttonClassName
           )}


### PR DESCRIPTION
…inputs

- Agregar padding y z-index al botón de mostrar/ocultar contraseña
- Mejorar área de hover del tooltip en FieldWrapper con inline-block
- Aumentar z-index del tooltip a z-50 para evitar interferencias
- Agregar pointer-events-none al tooltip para mejor UX