### PR TITLE
feat: optimizar landing para pantallas pequeñas y reducir tamaño de t…

### DIFF
--- a/src/components/organisms/ApplicationCard/components/ApplicationCardGlass.ui.tsx
+++ b/src/components/organisms/ApplicationCard/components/ApplicationCardGlass.ui.tsx
@@ -12,7 +12,7 @@ export const ApplicationCardGlass = ({ application, onViewDetail, onEdit, onDele
     <div className="relative bg-gradient-to-r from-blue-500 to-violet-500 rounded-2xl sm:rounded-3xl shadow-xl p-0 overflow-hidden backdrop-blur-md border border-blue-400/20 max-w-full sm:max-w-xs mx-auto" style={{ boxShadow: '0 4px 24px 0 rgba(80, 112, 255, 0.15)' }}>
       {/* Avatar - más pequeño en móvil */}
       <div className="flex justify-center items-center pt-4 sm:pt-6">
-        <div className="w-16 h-16 sm:w-20 sm:h-20 md:w-28 md:h-28 rounded-full bg-gradient-to-tr from-blue-400 to-blue-700 flex items-center justify-center text-white text-2xl sm:text-3xl md:text-4xl font-bold shadow-lg border-2 sm:border-4 border-blue-300/40">
+        <div className="w-16 h-16 sm:w-20 sm:h-20 md:w-28 md:h-28 rounded-full bg-gradient-to-tr from-blue-400 to-blue-700 flex items-center justify-center text-white text-xl sm:text-2xl md:text-3xl font-bold shadow-lg border-2 sm:border-4 border-blue-300/40">
           {initials}
         </div>
       </div>
@@ -24,30 +24,30 @@ export const ApplicationCardGlass = ({ application, onViewDetail, onEdit, onDele
       </div>
       {/* Stats - más compacto en móvil */}
       <div className="flex flex-col sm:flex-row justify-center gap-1 sm:gap-2 mt-3 sm:mt-6 mb-2 px-3 sm:px-4">
-        <div className="bg-white/10 rounded-lg sm:rounded-xl px-2 sm:px-3 py-1 sm:py-2 text-center text-sm text-white">
-          <div className="font-bold text-sm sm:text-xs lg:text-xs">{new Date(applicationDate).toLocaleDateString(lang === 'en' ? 'en-US' : 'es-ES', { day: '2-digit', month: 'short', year: '2-digit' })}</div>
-          <div className="opacity-70 text-sm">{translate('dashboard.date')}</div>
+        <div className="bg-white/10 rounded-lg sm:rounded-xl px-2 sm:px-3 py-1 sm:py-2 text-center text-xs text-white">
+          <div className="font-bold text-xs sm:text-xs lg:text-xs">{new Date(applicationDate).toLocaleDateString(lang === 'en' ? 'en-US' : 'es-ES', { day: '2-digit', month: 'short', year: '2-digit' })}</div>
+          <div className="opacity-70 text-xs">{translate('dashboard.date')}</div>
         </div>
-        <div className="bg-white/10 rounded-lg sm:rounded-xl px-2 sm:px-3 py-1 sm:py-2 text-center text-sm text-white">
-          <div className="font-bold text-sm sm:text-xs lg:text-xs truncate">{position}</div>
-          <div className="opacity-70 text-sm">{translate('dashboard.position')}</div>
+        <div className="bg-white/10 rounded-lg sm:rounded-xl px-2 sm:px-3 py-1 sm:py-2 text-center text-xs text-white">
+          <div className="font-bold text-xs sm:text-xs lg:text-xs truncate">{position}</div>
+          <div className="opacity-70 text-xs">{translate('dashboard.position')}</div>
         </div>
-        <div className="bg-white/10 rounded-lg sm:rounded-xl px-2 sm:px-3 py-1 sm:py-2 text-center text-sm text-white">
-          <div className="font-bold text-sm sm:text-xs lg:text-xs truncate">{company}</div>
-          <div className="opacity-70 text-sm">{translate('dashboard.company')}</div>
+        <div className="bg-white/10 rounded-lg sm:rounded-xl px-2 sm:px-3 py-1 sm:py-2 text-center text-xs text-white">
+          <div className="font-bold text-xs sm:text-xs lg:text-xs truncate">{company}</div>
+          <div className="opacity-70 text-xs">{translate('dashboard.company')}</div>
         </div>
       </div>
       {/* Badges de envío de CV y Email - más compacto */}
       {(sendCv || sendEmail) && (
         <div className="flex justify-center gap-1 sm:gap-2 mb-2 px-3 sm:px-4">
           {sendCv && (
-            <span key={`cv-badge-${application.id}`} className="flex items-center gap-1 bg-blue-100 text-blue-700 text-sm font-medium px-1 sm:px-2 py-1 rounded-full">
+            <span key={`cv-badge-${application.id}`} className="flex items-center gap-1 bg-blue-100 text-blue-700 text-xs font-medium px-1 sm:px-2 py-1 rounded-full">
               <svg className="w-3 h-3 sm:w-4 sm:h-4 text-blue-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>
               <span className="hidden sm:inline">{translate('dashboard.sentCV')}</span>
             </span>
           )}
           {sendEmail && (
-            <span key={`email-badge-${application.id}`} className="flex items-center gap-1 bg-blue-100 text-blue-700 text-sm font-medium px-1 sm:px-2 py-1 rounded-full">
+            <span key={`email-badge-${application.id}`} className="flex items-center gap-1 bg-blue-100 text-blue-700 text-xs font-medium px-1 sm:px-2 py-1 rounded-full">
               <svg className="w-3 h-3 sm:w-4 sm:h-4 text-blue-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>
               <span className="hidden sm:inline">{translate('dashboard.sentEmail')}</span>
             </span>
@@ -55,18 +55,18 @@ export const ApplicationCardGlass = ({ application, onViewDetail, onEdit, onDele
         </div>
       )}
       {/* Descripción/notas - más compacto */}
-      <div className="px-3 sm:px-6 py-1 sm:py-2 text-white/90 text-sm sm:text-base lg:text-xs min-h-[32px] sm:min-h-[48px]">
+      <div className="px-3 sm:px-6 py-1 sm:py-2 text-white/90 text-xs sm:text-sm lg:text-xs min-h-[32px] sm:min-h-[48px]">
         {description ? (
           <div className="line-clamp-2 sm:line-clamp-3">{description}</div>
         ) : (
-          <span className="italic text-blue-200 flex items-center gap-1 sm:gap-2 text-sm sm:text-base lg:text-xs">
+          <span className="italic text-blue-200 flex items-center gap-1 sm:gap-2 text-xs sm:text-sm lg:text-xs">
             <svg className="w-3 h-3 sm:w-4 sm:h-4 text-blue-300" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01" /></svg>
             {translate('dashboard.notes.none') || 'Sin notas aún'}
           </span>
         )}
       </div>
       {/* URL - oculto en móvil para ahorrar espacio */}
-      <div className="hidden sm:block px-6 pb-2 text-blue-200 text-sm truncate">
+      <div className="hidden sm:block px-6 pb-2 text-blue-200 text-xs truncate">
         {link ? (
           <a href={link} target="_blank" rel="noopener noreferrer" className="underline">{link}</a>
         ) : (
@@ -85,7 +85,7 @@ export const ApplicationCardGlass = ({ application, onViewDetail, onEdit, onDele
       <div className="flex justify-center items-center gap-1 sm:gap-2 md:gap-3 py-2 sm:py-3">
         <button
           onClick={onViewDetail}
-          className="flex items-center justify-center bg-pink-500 hover:bg-pink-600 text-white px-2 sm:px-3 py-1 sm:py-2 rounded-lg sm:rounded-xl shadow-2xl text-base sm:text-base lg:text-xs transition-all duration-200 group relative"
+          className="flex items-center justify-center bg-pink-500 hover:bg-pink-600 text-white px-2 sm:px-3 py-1 sm:py-2 rounded-lg sm:rounded-xl shadow-2xl text-sm sm:text-sm lg:text-xs transition-all duration-200 group relative"
           style={{ boxShadow: '0 12px 40px 0 rgba(236, 72, 153, 0.45), 0 6px 16px 0 rgba(236, 72, 153, 0.35)' }}
           title={translate('dashboard.actions.view')}
         >
@@ -96,7 +96,7 @@ export const ApplicationCardGlass = ({ application, onViewDetail, onEdit, onDele
         </button>
         <button
           onClick={onEdit}
-          className="flex items-center justify-center bg-blue-500 hover:bg-blue-600 text-white px-2 sm:px-3 py-1 sm:py-2 rounded-lg sm:rounded-xl shadow-2xl text-base sm:text-base lg:text-xs transition-all duration-200 group relative"
+          className="flex items-center justify-center bg-blue-500 hover:bg-blue-600 text-white px-2 sm:px-3 py-1 sm:py-2 rounded-lg sm:rounded-xl shadow-2xl text-sm sm:text-sm lg:text-xs transition-all duration-200 group relative"
           style={{ boxShadow: '0 12px 40px 0 rgba(59, 130, 246, 0.45), 0 6px 16px 0 rgba(59, 130, 246, 0.35)' }}
           title={translate('dashboard.actions.edit')}
         >
@@ -109,7 +109,7 @@ export const ApplicationCardGlass = ({ application, onViewDetail, onEdit, onDele
         </button>
         <button
           onClick={onDelete}
-          className="flex items-center justify-center bg-red-500 hover:bg-red-600 text-white px-2 sm:px-3 py-1 sm:py-2 rounded-lg sm:rounded-xl shadow-2xl text-base sm:text-base lg:text-xs transition-all duration-200 group relative"
+          className="flex items-center justify-center bg-red-500 hover:bg-red-600 text-white px-2 sm:px-3 py-1 sm:py-2 rounded-lg sm:rounded-xl shadow-2xl text-sm sm:text-sm lg:text-xs transition-all duration-200 group relative"
           style={{ boxShadow: '0 12px 40px 0 rgba(239, 68, 68, 0.45), 0 6px 16px 0 rgba(239, 68, 68, 0.35)' }}
           title={translate('dashboard.actions.delete')}
         >

--- a/src/features/landing/components/CTASection.ui.tsx
+++ b/src/features/landing/components/CTASection.ui.tsx
@@ -15,7 +15,7 @@ const CTASection: React.FC<CTASectionExtendedProps> = ({translate, onJoinWaitlis
   };
 
   return (
-    <div className="relative w-full py-24 overflow-hidden">
+    <div className="relative w-full py-12 sm:py-16 md:py-24 overflow-hidden">
       <div
         className="absolute inset-0 bg-cover bg-center bg-no-repeat"
         style={{
@@ -31,7 +31,7 @@ const CTASection: React.FC<CTASectionExtendedProps> = ({translate, onJoinWaitlis
           whileInView="visible"
           transition={{ duration: 0.8 }}
           viewport={{ once: true }}
-          className="mt-16 text-center mb-16 md:mb-32"
+          className="mt-8 sm:mt-12 md:mt-16 text-center mb-8 sm:mb-12 md:mb-16 lg:mb-32"
         >
 <motion.h3
   variants={fadeInUpVariants}
@@ -39,7 +39,7 @@ const CTASection: React.FC<CTASectionExtendedProps> = ({translate, onJoinWaitlis
   whileInView="visible"
   transition={{ duration: 0.8, delay: 0.2 }}
   viewport={{ once: true }}
-  className="text-4xl md:text-6xl font-extrabold text-center mb-14 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 bg-clip-text text-transparent drop-shadow-lg"
+  className="text-2xl sm:text-3xl md:text-4xl lg:text-6xl font-extrabold text-center mb-8 sm:mb-10 md:mb-14 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 bg-clip-text text-transparent drop-shadow-lg"
 >
   {translate('landing.cta.title')}
 </motion.h3>
@@ -48,7 +48,7 @@ const CTASection: React.FC<CTASectionExtendedProps> = ({translate, onJoinWaitlis
             whileInView={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.4 }}
             viewport={{ once: true }}
-            className="text-white mb-12 max-w-3xl mx-auto text-lg md:text-xl drop-shadow-lg rounded-xl px-6 py-4 inline-block"
+            className="text-white mb-8 sm:mb-10 md:mb-12 max-w-3xl mx-auto text-sm sm:text-base md:text-lg lg:text-xl drop-shadow-lg rounded-xl px-4 sm:px-6 py-3 sm:py-4 inline-block"
           >
             {translate('landing.cta.description')}
           </motion.p>
@@ -61,7 +61,7 @@ const CTASection: React.FC<CTASectionExtendedProps> = ({translate, onJoinWaitlis
             <button
               type="button"
               onClick={onJoinWaitlist}
-              className="group inline-flex items-center justify-center px-10 py-5 rounded-2xl shadow-lg text-white font-extrabold text-lg transition-all duration-300 bg-gradient-to-r from-blue-500 to-violet-500 hover:from-blue-600 hover:to-violet-600 focus:outline-none focus:ring-2 focus:ring-blue-400 w-[320px] whitespace-nowrap gap-4 hover:scale-105 hover:shadow-xl"
+              className="group inline-flex items-center justify-center px-6 sm:px-8 md:px-10 py-3 sm:py-4 md:py-5 rounded-2xl shadow-lg text-white font-extrabold text-base sm:text-lg transition-all duration-300 bg-gradient-to-r from-blue-500 to-violet-500 hover:from-blue-600 hover:to-violet-600 focus:outline-none focus:ring-2 focus:ring-blue-400 w-[280px] sm:w-[300px] md:w-[320px] whitespace-nowrap gap-3 sm:gap-4 hover:scale-105 hover:shadow-xl"
               aria-label="Únete a nuestra lista de espera"
               style={{
                 boxShadow: '0 4px 24px 0 rgba(80, 112, 255, 0.15)',
@@ -69,7 +69,7 @@ const CTASection: React.FC<CTASectionExtendedProps> = ({translate, onJoinWaitlis
               }}
             >
               Únete a nuestra lista de espera
-              <ArrowRight className="h-5 w-5 text-white transform transition-transform duration-300 group-hover:translate-x-1" aria-hidden="true" />
+              <ArrowRight className="h-4 w-4 sm:h-5 sm:w-5 text-white transform transition-transform duration-300 group-hover:translate-x-1" aria-hidden="true" />
             </button>
           </motion.div>
         </motion.div>

--- a/src/features/landing/components/HeroSection.ui.tsx
+++ b/src/features/landing/components/HeroSection.ui.tsx
@@ -13,20 +13,20 @@ function highlightImportant(text: string) {
 const HeroSection: React.FC = () => {
   const translate = useLanguageStore(state=>state.translate);
   return (
-    <section className="relative min-h-[calc(100vh-0px)] flex items-center justify-center pt-16 sm:pt-20 md:pt-24 pb-16 sm:pb-20 md:pb-24 px-4 sm:px-6">
-      <div className="container mx-auto flex flex-col-reverse md:flex-row items-center justify-between gap-4 md:gap-2 text-center md:text-left relative z-10">
+    <section className="relative min-h-[calc(100vh-0px)] flex items-center justify-center pt-8 sm:pt-12 md:pt-16 pb-8 sm:pb-12 md:pb-16 px-4 sm:px-6">
+      <div className="container mx-auto flex flex-col-reverse md:flex-row items-center justify-between gap-2 md:gap-2 text-center md:text-left relative z-10">
         {/* Columna izquierda: textos */}
-        <div className="w-full md:w-1/2 flex flex-col items-center md:items-start justify-center min-h-[400px] sm:min-h-[480px]">
+        <div className="w-full md:w-1/2 flex flex-col items-center md:items-start justify-center min-h-[300px] sm:min-h-[350px]">
           <motion.div
-            className="flex justify-center md:justify-start mb-6 sm:mb-8"
+            className="flex justify-center md:justify-start mb-4 sm:mb-6"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, ease: 'easeOut' }}
           >
-            <Briefcase className="h-16 w-16 sm:h-20 sm:w-20 text-white drop-shadow-[0_0_24px_rgba(80,112,255,0.5)]" />
+            <Briefcase className="h-12 w-12 sm:h-16 sm:w-16 md:h-20 md:w-20 text-white drop-shadow-[0_0_24px_rgba(80,112,255,0.5)]" />
           </motion.div>
           <motion.h1
-            className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-extrabold text-white mb-4 sm:mb-6 drop-shadow-[0_2px_24px_rgba(80,112,255,0.45)]"
+            className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold text-white mb-3 sm:mb-4 drop-shadow-[0_2px_24px_rgba(80,112,255,0.45)]"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, ease: 'easeOut' }}
@@ -36,7 +36,7 @@ const HeroSection: React.FC = () => {
 
           {/* Subtítulo SEO optimizado */}
           <motion.h2
-            className="text-lg sm:text-xl md:text-2xl lg:text-3xl text-white font-bold mb-4 sm:mb-6 drop-shadow-lg text-center md:text-left"
+            className="text-base sm:text-lg md:text-xl lg:text-2xl text-white font-bold mb-3 sm:mb-4 drop-shadow-lg text-center md:text-left"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.7, delay: 0.1, ease: 'easeOut' }}
@@ -45,7 +45,7 @@ const HeroSection: React.FC = () => {
           </motion.h2>
 
           <motion.div
-            className="text-base sm:text-lg md:text-xl lg:text-2xl text-white font-semibold max-w-2xl mb-6 sm:mb-10 text-center md:text-left drop-shadow-lg flex flex-wrap items-center justify-center md:justify-start"
+            className="text-sm sm:text-base md:text-lg lg:text-xl text-white font-semibold max-w-2xl mb-4 sm:mb-6 text-center md:text-left drop-shadow-lg flex flex-wrap items-center justify-center md:justify-start"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.2, ease: 'easeOut' }}
@@ -62,7 +62,7 @@ const HeroSection: React.FC = () => {
 
           {/* Descripción adicional para SEO */}
           <motion.p
-            className="text-sm sm:text-base md:text-lg text-white/90 max-w-xl mb-6 sm:mb-8 text-center md:text-left drop-shadow-md"
+            className="text-xs sm:text-sm md:text-base text-white/90 max-w-xl mb-4 sm:mb-6 text-center md:text-left drop-shadow-md"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.25, ease: 'easeOut' }}
@@ -71,21 +71,21 @@ const HeroSection: React.FC = () => {
           </motion.p>
 
           <motion.div
-            className="flex flex-col sm:flex-row justify-center md:justify-start gap-4 sm:gap-6 w-full sm:w-auto"
+            className="flex flex-col sm:flex-row justify-center md:justify-start gap-3 sm:gap-4 w-full sm:w-auto"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8, delay: 0.3, ease: 'easeOut' }}
           >
             <Link
               to="/login"
-              className="inline-flex items-center justify-center px-6 sm:px-8 py-3 sm:py-4 rounded-xl shadow-xl text-white font-extrabold text-lg sm:text-xl transition bg-gradient-to-r from-blue-500 to-violet-500 hover:from-blue-600 hover:to-violet-600 focus:outline-none focus:ring-2 focus:ring-blue-400 w-full sm:w-[220px] whitespace-nowrap"
+              className="inline-flex items-center justify-center px-4 sm:px-6 py-2 sm:py-3 rounded-xl shadow-xl text-white font-extrabold text-base sm:text-lg transition bg-gradient-to-r from-blue-500 to-violet-500 hover:from-blue-600 hover:to-violet-600 focus:outline-none focus:ring-2 focus:ring-blue-400 w-full sm:w-[200px] whitespace-nowrap"
               aria-label="Iniciar sesión en Postulate"
             >
               {translate('login')}
             </Link>
             <Link
               to="/register"
-              className="inline-flex items-center justify-center px-6 sm:px-8 py-3 sm:py-4 rounded-xl shadow-xl text-blue-700 font-extrabold text-lg sm:text-xl transition bg-white border border-blue-300 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-400 w-full sm:w-[220px] whitespace-nowrap"
+              className="inline-flex items-center justify-center px-4 sm:px-6 py-2 sm:py-3 rounded-xl shadow-xl text-blue-700 font-extrabold text-base sm:text-lg transition bg-white border border-blue-300 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-400 w-full sm:w-[200px] whitespace-nowrap"
               aria-label="Crear cuenta en Postulate"
             >
               {translate('register')}

--- a/src/features/landing/components/HowItWorksSection.ui.tsx
+++ b/src/features/landing/components/HowItWorksSection.ui.tsx
@@ -32,8 +32,8 @@ const HowItWorksSection: React.FC<HowItWorksSectionProps> = ({ translate }) => {
   ];
 
   return (
-    <div className="text-center py-24 md:py-32 min-h-[600px]">
-      <h2 className="text-4xl md:text-5xl font-extrabold text-center mb-14 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 bg-clip-text text-transparent">
+    <div className="text-center py-12 sm:py-16 md:py-24 min-h-[400px] sm:min-h-[500px]">
+      <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-8 sm:mb-12 md:mb-14 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 bg-clip-text text-transparent">
         {translate('landing.howItWorks.title')}
       </h2>
       <div className="w-full max-w-6xl mx-auto px-2 lg:px-0">
@@ -50,7 +50,7 @@ const HowItWorksSection: React.FC<HowItWorksSectionProps> = ({ translate }) => {
                         display: 'block',
                         objectFit: 'cover',
                         width: '100%',
-                        height: 140,
+                        height: 120,
                         backgroundColor: 'var(--gray-5)',
                         borderTopLeftRadius: '1.5rem',
                         borderTopRightRadius: '1.5rem',
@@ -67,8 +67,8 @@ const HowItWorksSection: React.FC<HowItWorksSectionProps> = ({ translate }) => {
                     </div>
                   </Inset>
                 </div>
-                <div className="flex flex-col items-center px-4 pb-8 pt-6">
-                  <Text as="div" size="5" className="font-semibold text-gray-100 mb-4 drop-shadow-sm">{step.title}</Text>
+                <div className="flex flex-col items-center px-3 sm:px-4 pb-6 sm:pb-8 pt-4 sm:pt-6">
+                  <Text as="div" size="5" className="font-semibold text-gray-100 mb-3 sm:mb-4 drop-shadow-sm">{step.title}</Text>
                   <Text as="p" size="3" className="text-gray-100 drop-shadow-sm" style={{paddingBottom: '0.5rem'}}>{step.description}</Text>
                 </div>
               </Card>

--- a/src/features/landing/components/TrustSection.ui.tsx
+++ b/src/features/landing/components/TrustSection.ui.tsx
@@ -49,8 +49,8 @@ const TrustSection: React.FC<TrustSectionProps> = ({ translate }) => {
 
 
   return (
-    <section className="py-20 sm:py-32 flex flex-col items-center w-full min-h-[60vh]">
-      <h2 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-center mb-8 sm:mb-14 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 bg-clip-text text-transparent px-4">
+    <section className="py-12 sm:py-20 md:py-32 flex flex-col items-center w-full min-h-[40vh] sm:min-h-[50vh] md:min-h-[60vh]">
+      <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold text-center mb-6 sm:mb-10 md:mb-14 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 bg-clip-text text-transparent px-4">
         {translate('landing.trust.title')}
       </h2>
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 sm:gap-8 w-full max-w-7xl px-4 sm:px-6">
@@ -63,13 +63,13 @@ const TrustSection: React.FC<TrustSectionProps> = ({ translate }) => {
             className="w-full"
           >
             <div
-              className={`flex flex-col items-center justify-start border border-transparent shadow-2xl rounded-3xl min-h-[22rem] py-8 px-6 bg-gradient-to-r from-blue-500 to-violet-500 dark:from-blue-400 dark:to-violet-400 transition-transform duration-300 hover:scale-105`}
+              className={`flex flex-col items-center justify-start border border-transparent shadow-2xl rounded-3xl min-h-[18rem] sm:min-h-[20rem] md:min-h-[22rem] py-6 sm:py-8 px-4 sm:px-6 bg-gradient-to-r from-blue-500 to-violet-500 dark:from-blue-400 dark:to-violet-400 transition-transform duration-300 hover:scale-105`}
             >
               {card.icon}
-              <span className="text-2xl sm:text-2xl md:text-3xl font-extrabold text-white text-center leading-tight tracking-tight drop-shadow-lg select-none w-full mb-2">
+              <span className="text-xl sm:text-2xl md:text-3xl font-extrabold text-white text-center leading-tight tracking-tight drop-shadow-lg select-none w-full mb-2">
                 {translate(card.titleKey as TranslationKey)}
               </span>
-              <span className="text-base sm:text-lg md:text-xl text-white text-center font-medium tracking-tight leading-relaxed select-none w-full mt-2">
+              <span className="text-sm sm:text-base md:text-lg lg:text-xl text-white text-center font-medium tracking-tight leading-relaxed select-none w-full mt-2">
                 {translate(card.textKey as TranslationKey)}
               </span>
             </div>

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -50,7 +50,7 @@ const Landing: React.FC = () => {
           <div className="border-b border-white/70 mb-10" />
         </div>
 
-        <motion.div id="how-it-works" initial={{ opacity: 0, y: 40 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.7 }} className="relative w-full py-20">
+        <motion.div id="how-it-works" initial={{ opacity: 0, y: 40 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.7 }} className="relative w-full py-12 sm:py-16 md:py-20">
           <div className="absolute inset-0 bg-cover bg-center bg-no-repeat" style={{ backgroundImage: 'url(https://images.unsplash.com/photo-1552664730-d307ca884978?auto=format&fit=crop&w=1920&q=80)' }}>
             <div className="absolute inset-0 bg-black/60" />
           </div>
@@ -63,7 +63,7 @@ const Landing: React.FC = () => {
           <FeaturesSectionContainer translate={translate} />
         </motion.div>
 
-        <motion.div id="benefits" initial={{ opacity: 0, y: 40 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.7, delay: 0.2 }} className="relative w-full py-20">
+        <motion.div id="benefits" initial={{ opacity: 0, y: 40 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.7, delay: 0.2 }} className="relative w-full py-12 sm:py-16 md:py-20">
           <div className="absolute inset-0 bg-cover bg-center bg-no-repeat" style={{ backgroundImage: 'url(https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1920&q=80)' }}>
             <div className="absolute inset-0 bg-black/60" />
           </div>


### PR DESCRIPTION
…exto en notebooks

- Reducir espaciado y tamaños de texto en HeroSection para pantallas < 750px
- Optimizar HowItWorksSection con padding y altura mínima reducidos
- Ajustar TrustSection y CTASection para mejor visualización en móvil
- Reducir tamaño de fuente en ApplicationCardGlass en un punto
- Mejorar responsividad general del landing page